### PR TITLE
Make tooltip open on hover

### DIFF
--- a/src/components/receipt-view/receipt-section/ReceiptSection.js
+++ b/src/components/receipt-view/receipt-section/ReceiptSection.js
@@ -71,7 +71,9 @@ const ReceiptSection = ({ cartState }) => {
             </Grid>
             <Grid item xs={1}>
               <ClickAwayListener onClickAway={handleTooltipClose}>
-                <div>
+                <div
+                  onMouseEnter={handleTooltipOpen}
+                  onMouseLeave={handleTooltipClose}>
                   <Tooltip
                     PopperProps={{
                       disablePortal: true,
@@ -81,7 +83,10 @@ const ReceiptSection = ({ cartState }) => {
                     disableTouchListener
                     arrow
                     title={INFO_TEXT}>
-                    <InfoOutlinedIcon onClick={handleTooltipOpen} />
+                    <InfoOutlinedIcon
+                      onClick={handleTooltipOpen}
+                      onHover={handleTooltipOpen}
+                    />
                   </Tooltip>
                 </div>
               </ClickAwayListener>


### PR DESCRIPTION
When I added click support, I must have disabled hover support for the tooltip icon on the receipt. Fixed!